### PR TITLE
👷 Create automergable PR when dist folder is changed

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   dist-changed:
@@ -32,4 +33,12 @@ jobs:
           git config --global user.email 'octocat@users.noreply.github.com'
           git add dist/
           git commit -m "🧹 Update dist folder"
-          git push
+      - name: Create PR
+        if: ${{ env.EXIT_CODE_DIST_CHANGED == 1 }}
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+      - name: Automerge PR
+        if: ${{ env.EXIT_CODE_DIST_CHANGED == 1 }}
+        run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With branch protection enabled, its not possible to push to said branch with the default github token (even with permissions content: write). 

To avoid this, we create a PR with this changed and let it merge automatically as soon as CI passes