### PR TITLE
💥 Upgrade node 16 to node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action can be run on `ubuntu-latest`, `windows-latest`, and `macos-latest` 
 
 ```yml
 steps:
-  - uses: wtfjoke/setup-groovy@v1
+  - uses: wtfjoke/setup-groovy@v2
     with:
       groovy-version: '4.x'
   - run: groovy --version
@@ -32,7 +32,7 @@ If there is a specific version of Groovy that you need and you don't want to wor
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: wtfjoke/setup-groovy@v1
+  - uses: wtfjoke/setup-groovy@v2
     with:
       groovy-version: '4.0.9'
   - run: groovy HelloWorld.groovy
@@ -43,7 +43,7 @@ You can specify **only a major and minor version** if you are okay with the most
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: wtfjoke/setup-groovy@v1
+  - uses: wtfjoke/setup-groovy@v2
     with:
       groovy-version: '4.0'
   - run: groovy HelloWorld.groovy
@@ -54,7 +54,7 @@ You can also use ranges that are specified in [semver](https://github.com/npm/no
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: wtfjoke/setup-groovy@v1
+  - uses: wtfjoke/setup-groovy@v2
     with:
       groovy-version: '>=3.x <4.0.0'
   - run: groovy HelloWorld.groovy

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: 'The version of Groovy to install. Exact version or version range of Groovy. Using semver version range syntax. Examples: 4.x, 4.0.x, 4.0.9, 4.0.0-rc-1, etc.'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: star

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@octokit/types": "11.1.0",
     "@types/jest": "29.5.5",
-    "@types/node": "16.18.50",
+    "@types/node": "20.6.2",
     "@types/semver": "7.5.2",
     "@typescript-eslint/parser": "6.7.0",
     "@vercel/ncc": "0.38.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -930,10 +930,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
   integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
-"@types/node@16.18.50":
-  version "16.18.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.50.tgz#93003cf0251a2ecd26dad6dc757168d648519805"
-  integrity sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==
+"@types/node@20.6.2":
+  version "20.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.2.tgz#a065925409f59657022e9063275cd0b9bd7e1b12"
+  integrity sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw==
 
 "@types/semver@7.5.2":
   version "7.5.2"


### PR DESCRIPTION
Node 16 is end of life
(see https://nodejs.org/de/blog/announcements/nodejs16-eol)

Node 20 is the next lts version and supported by github actions runner
(see https://github.com/actions/runner/issues/2619#issuecomment-1679003443, however there is no docs update or blog post available yet)